### PR TITLE
Add full-screen overlay example

### DIFF
--- a/fullscreen.html
+++ b/fullscreen.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Full-screen Background with Overlay</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      font-family: 'Poppins', sans-serif;
+    }
+
+    .hero {
+      position: relative;
+      min-height: 100vh;
+      width: 100%;
+      background: url('watercolor_background_2.png') center/cover no-repeat;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      text-align: center;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+    }
+
+    .hero-content {
+      position: relative;
+      padding: 2rem;
+      background: rgba(0,0,0,0.6);
+      border-radius: 8px;
+      max-width: 90vw;
+    }
+
+    .hero-content h1 {
+      font-size: clamp(1.5rem, 5vw, 3rem);
+      margin: 0 0 0.5rem;
+    }
+
+    .hero-content p {
+      font-size: clamp(1rem, 3vw, 1.5rem);
+      margin: 0;
+    }
+
+    .sample-content {
+      padding: 2rem 1rem;
+      max-width: 800px;
+      margin: auto;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <section class="hero">
+    <div class="hero-content">
+      <h1>Welcome to Our Celebration</h1>
+      <p>Scroll down for more information</p>
+    </div>
+  </section>
+
+  <div class="sample-content">
+    <h2>Sample Content</h2>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget co
+      nvallis nibh. Donec imperdiet, augue at tristique placerat, orci lec
+      tus eleifend risus, at fermentum velit urna at libero. Vestibulum co
+      nsectetur feugiat elit, vel posuere sapien faucibus id.
+    </p>
+    <p>
+      Curabitur faucibus augue nec finibus fermentum. Aenean sit amet ex p
+      retium, rhoncus neque sed, fermentum elit. Quisque ut convallis nisl
+      , vel feugiat ligula. Integer volutpat finibus commodo. Nulla facil
+      isi.
+    </p>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,9 +11,8 @@
 </head>
 <body>
 
-  <header class="hero-header">
-    <img src="anne_morten_banner.jpg" alt="Anne og Morten" class="hero-img">
-    <div class="hero-text">
+  <header class="hero">
+    <div class="hero-content">
       <h1>Anne & Morten</h1>
       <p>Gifter seg 27. juni 2026</p>
     </div>

--- a/style.css
+++ b/style.css
@@ -19,37 +19,41 @@ body {
   line-height: 1.6;
 }
 
-header.hero-header {
+.hero {
   position: relative;
-  height: 70vh;
+  min-height: 100vh;
   width: 100%;
-  overflow: hidden;
-}
-
-header.hero-header img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.hero-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  background: url('anne_morten_banner.jpg') center/cover no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
   text-align: center;
-  color: white;
-  text-shadow: 0 2px 4px rgba(0,0,0,0.4);
 }
 
-.hero-text h1 {
-  font-size: 3rem;
-  margin-bottom: 0.5rem;
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
 }
 
-.hero-text p {
-  font-size: 1.5rem;
+.hero-content {
+  position: relative;
+  padding: 2rem;
+  background: rgba(0,0,0,0.6);
+  border-radius: 8px;
+  max-width: 90vw;
+}
+
+.hero-content h1 {
+  font-size: clamp(1.5rem, 5vw, 3rem);
+  margin: 0 0 0.5rem;
+}
+
+.hero-content p {
+  font-size: clamp(1rem, 3vw, 1.5rem);
+  margin: 0;
 }
 
 section {


### PR DESCRIPTION
## Summary
- add a standalone `fullscreen.html` with a responsive hero section
- update index to use the same full-screen hero overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68827076f478832b8cb0b14e12f89c18