### PR TITLE
Restore hero image and apply kart background to sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: #665d1e;
   text-align: center;
 }
 
@@ -60,6 +60,7 @@ section {
   max-width: 900px;
   margin: 3rem auto;
   padding: 0 1rem;
+  background: url('kart.png') center/cover no-repeat;
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- keep `anne_morten_banner.jpg` as hero background
- use `kart.png` as background image for all content sections

## Testing
- `tidy -e index.html`
- `tidy -e takk.html`
- `tidy -e fullscreen.html`


------
https://chatgpt.com/codex/tasks/task_e_68828b66bad8832bb2bbd25ce5d718c5