### PR TITLE
Add sticky banner transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,12 +154,21 @@
   <script>
     const hero = document.querySelector('.hero');
     const body = document.body;
+    const stickyHeight = 80;
+    const heroHeight = hero.offsetHeight;
 
     window.addEventListener('scroll', () => {
-      const ratio = Math.min(window.scrollY / hero.offsetHeight, 1);
+      const ratio = Math.min(window.scrollY / heroHeight, 1);
       hero.style.filter = `grayscale(${ratio * 100}%)`;
-      hero.style.opacity = `${1 - ratio}`;
       body.style.setProperty('--bg-opacity', ratio * 0.5);
+
+      if (window.scrollY > heroHeight - stickyHeight) {
+        hero.classList.add('sticky');
+        body.style.paddingTop = `${stickyHeight}px`;
+      } else {
+        hero.classList.remove('sticky');
+        body.style.paddingTop = '';
+      }
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -35,14 +35,15 @@ body::before {
 
 .hero {
   position: relative;
-  min-height: 100vh;
+  height: 100vh;
   width: 100%;
   background: url('anne_morten_banner.jpg') center/cover no-repeat;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
-  transition: filter 0.5s ease-out, opacity 0.5s ease-out;
+  transition: filter 0.5s ease-out, height 0.5s ease-out;
+  z-index: 10;
 }
 
 .hero::before {
@@ -62,6 +63,7 @@ body::before {
   color: rgba(255,255,255,0.7);
   border-radius: 8px;
   max-width: 90vw;
+  transition: all 0.5s ease-out;
 }
 
 .hero-content h1 {
@@ -72,6 +74,40 @@ body::before {
 .hero-content p {
   font-size: clamp(1rem, 3vw, 1.5rem);
   margin: 0;
+}
+
+.hero.sticky {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+}
+
+.hero.sticky .hero-content {
+  position: relative;
+  left: auto;
+  bottom: auto;
+  transform: none;
+  background: rgba(255,255,255,0.9);
+  color: var(--text);
+  padding: 0.5rem 1rem;
+  border-radius: 0;
+  max-width: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.hero.sticky .hero-content p {
+  display: none;
+}
+
+.hero.sticky .hero-content h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--primary-dark);
 }
 
 section {


### PR DESCRIPTION
## Summary
- make hero banner sticky when scrolled
- style shrunken banner for top of page
- adjust JS to toggle sticky class on scroll

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883adb086e8832b9e5f31b5e9a0b804