### PR TITLE
Improve theme colors and timeline layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@
       <h2>Førfest (fredag)</h2>
       <ul class="timeline">
         <li class="timeline-item">
-          <img src="fredag.png" alt="Fredag" />
           <div>
             <span class="timeline-time">18:00</span> Uformell samling på Pensjonat Bergdalen
             <ul class="sub-steps">
@@ -42,7 +41,6 @@
           </div>
         </li>
         <li class="timeline-item">
-          <img src="restaurant.png" alt="Restaurant" />
           <div>
             <span class="timeline-time">20:00</span> Middag på restaurant
             <ul class="sub-steps">
@@ -56,7 +54,6 @@
       <h2>Bryllupsdagen (lørdag)</h2>
       <ul class="timeline">
         <li class="timeline-item">
-          <img src="vielse.png" alt="Vielse" />
           <div>
             <span class="timeline-time">12:00</span> Vielse ved Valmutvägen 39a
             <ul class="sub-steps">
@@ -66,7 +63,6 @@
           </div>
         </li>
         <li class="timeline-item">
-          <img src="kart.png" alt="Transport" />
           <div>
             <span class="timeline-time">13:00</span> Båttur til Ekenäs
             <ul class="sub-steps">
@@ -77,7 +73,6 @@
           </div>
         </li>
         <li class="timeline-item">
-          <img src="hotell.png" alt="Hotell" />
           <div>
             <span class="timeline-time">15:00</span> Middag og fest på Ekenäs hotell
             <ul class="sub-steps">

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
   --bg: #d9e6dc;
-  --primary: #5a189a;
-  --primary-dark: #49147b;
+  --primary: #556B2F;
+  --primary-dark: #3b5323;
   --secondary: #e0d4ff;
   --text: #333;
 }
@@ -50,7 +50,7 @@ body::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: rgba(0,0,0,0.4);
+  background: rgba(0,0,0,0.2);
 }
 
 .hero-content {
@@ -59,7 +59,7 @@ body::before {
   bottom: 33%;
   transform: translateX(-50%);
   padding: 2rem;
-  background: rgba(255,255,255,0.5);
+  background: rgba(255,255,255,0.3);
   color: rgba(255,255,255,0.7);
   border-radius: 8px;
   max-width: 90vw;
@@ -132,13 +132,7 @@ h2 {
 }
 
 .timeline::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0.5rem;
-  bottom: 0.5rem;
-  width: 4px;
-  background: var(--secondary);
+  display: none;
 }
 
 .timeline-item {


### PR DESCRIPTION
## Summary
- switch brand colors to deep olive green
- lighten the hero overlays for more visible background image
- remove icons from the program timeline
- hide connecting line in the timeline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688478ac2e8c832b8c83789124ffcee6