### PR TITLE
Add sticky hero effect

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,7 +52,8 @@ body::before {
 }
 
 .hero {
-  position: relative;
+  position: sticky;
+  top: 0;
   min-height: 100vh;
   width: 100%;
   background: url('anne_morten_banner.jpg') center/cover no-repeat;
@@ -61,6 +62,7 @@ body::before {
   justify-content: center;
   text-align: center;
   transition: filter 0.5s ease-out, opacity 0.5s ease-out;
+  z-index: 0;
 }
 
 .hero::before {
@@ -100,6 +102,12 @@ section {
   max-width: 900px;
   margin: 3rem auto;
   padding: 0 1rem;
+}
+
+/* Ensure first text box overlays the sticky hero */
+body > section:first-of-type {
+  position: relative;
+  z-index: 1;
 }
 
 h2 {


### PR DESCRIPTION
## Summary
- keep the hero section sticky so it stays fixed while the first text box scrolls up
- ensure the first section overlays the hero when scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68865c907248832b830020322fed460f