### PR TITLE
Display site version

### DIFF
--- a/fullscreen.html
+++ b/fullscreen.html
@@ -83,5 +83,14 @@
       isi.
     </p>
   </div>
+  <p class="version" style="text-align:center;"></p>
+  <script>
+    fetch('package.json')
+      .then(r => r.json())
+      .then(pkg => {
+        const el = document.querySelector('.version');
+        if (el) el.textContent = `Versjon ${pkg.version}`;
+      });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -147,10 +147,20 @@
 
   <footer>
     <p>Mer informasjon kommer...</p>
+    <p class="version"></p>
   </footer>
   <script>
     const hero = document.querySelector('.hero');
     const body = document.body;
+
+    fetch('package.json')
+      .then(response => response.json())
+      .then(pkg => {
+        const el = document.querySelector('.version');
+        if (el) {
+          el.textContent = `Versjon ${pkg.version}`;
+        }
+      });
 
     window.addEventListener('scroll', () => {
       const ratio = Math.min(window.scrollY / hero.offsetHeight, 1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wedding_website",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Static site for Anne and Morten's wedding",
   "scripts": {
     "test": "echo \"No tests specified\""

--- a/takk.html
+++ b/takk.html
@@ -33,6 +33,17 @@
   <div class="message">
     <h1>Takk for svaret!</h1>
     <p>Hilsen Anne & Morten</p>
+    <p class="version"></p>
   </div>
+  <script>
+    fetch('package.json')
+      .then(response => response.json())
+      .then(pkg => {
+        const el = document.querySelector('.version');
+        if (el) {
+          el.textContent = `Versjon ${pkg.version}`;
+        }
+      });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add scripts that fetch package.json to display version
- show the version on all webpages
- bump minor version to 1.1.0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68865f027664832baf19700845d04732