### PR TITLE
Add plus-one checkbox and blur effect to sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,8 +133,11 @@
       </div>
 
       <div class="form-group">
-        <label for="guests">Antall gjester (inkludert deg selv)</label>
-        <input type="number" id="guests" name="Antall gjester" min="1" />
+        <label><input type="checkbox" id="plusone" name="Følge"> Følge</label>
+      </div>
+      <div class="form-group plusone-name" style="display: none;">
+        <label for="plusone-name">Navn på følge</label>
+        <input type="text" id="plusone-name" name="Følgenavn" />
       </div>
 
       <div class="form-group">
@@ -158,7 +161,15 @@
     const hero = document.querySelector('.hero');
     const heroText = document.querySelector('.hero-content');
     const body = document.body;
+    const plusOneCheckbox = document.getElementById('plusone');
+    const plusOneGroup = document.querySelector('.plusone-name');
     const maxShift = heroText.offsetTop - heroText.offsetHeight / 2;
+
+    if (plusOneCheckbox) {
+      plusOneCheckbox.addEventListener('change', () => {
+        plusOneGroup.style.display = plusOneCheckbox.checked ? 'flex' : 'none';
+      });
+    }
 
     fetch('package.json')
       .then(response => response.json())

--- a/style.css
+++ b/style.css
@@ -139,7 +139,8 @@ body > section:first-of-type {
 }
 
 .invite-text {
-  background: var(--white);
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(4px);
   padding: 3rem;
   border-radius: 12px;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
@@ -211,7 +212,8 @@ h3 {
 }
 
 form {
-  background: var(--secondary);
+  background: rgba(221, 213, 180, 0.7);
+  backdrop-filter: blur(4px);
   padding: 2rem;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.05);


### PR DESCRIPTION
## Summary
- replace guest count input with plus-one checkbox
- show companion name field when checked
- blur & fade invitation text and form background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688885076098832b9135f21703b1b969