### PR TITLE
Combine RSVP forms for dual submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
 
   <section>
     <h2>Gi oss beskjed</h2>
-    <form action="https://formsubmit.co/8b009dd70cad269011908a21e6491e64" method="POST">
+    <form id="rsvp-form" action="https://formsubmit.co/8b009dd70cad269011908a21e6491e64" method="POST">
       <div class="form-group">
         <label for="name">Navn</label>
         <input type="text" id="name" name="Navn" required />
@@ -169,18 +169,7 @@
       <button type="submit">Send svar</button>
     </form>
   </section>
-  <section>
-      <form action="https://script.google.com/macros/s/AKfycbzbQoYLX0n-QL7iLfK11YGtFtdMk_c8AfxrzAA76Q4MtZ0vvng98JFckvyOJKcpsnPL/exec" method="POST">
-      <input type="text" name="name" placeholder="Navn" required><br>
-      <input type="email" name="email" placeholder="Epost" required><br>
-      <select name="attending" required>
-        <option value="yes">Kommer</option>
-        <option value="no">Kan ikke</option>
-      </select><br>
-      <textarea name="comment" placeholder="Kommentarer"></textarea><br>
-      <button type="submit">Send inn</button>
-    </form>
-  </section>
+
 
   <footer>
     </p>Copyright © 2025 Anne & Morten</p>
@@ -196,6 +185,17 @@
     if (plusOneCheckbox) {
       plusOneCheckbox.addEventListener('change', () => {
         plusOneGroup.style.display = plusOneCheckbox.checked ? 'flex' : 'none';
+      });
+    }
+
+    const rsvpForm = document.getElementById('rsvp-form');
+    if (rsvpForm) {
+      rsvpForm.addEventListener('submit', () => {
+        fetch('https://script.google.com/macros/s/AKfycbzbQoYLX0n-QL7iLfK11YGtFtdMk_c8AfxrzAA76Q4MtZ0vvng98JFckvyOJKcpsnPL/exec', {
+          method: 'POST',
+          body: new FormData(rsvpForm),
+          mode: 'no-cors'
+        });
       });
     }
 


### PR DESCRIPTION
## Summary
- merge the two RSVP forms into one
- send submissions to both FormSubmit and the existing Google Apps Script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688897edbcb4832ba861245ff0e2cc6a