### PR TITLE
Add spacing between transport sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,6 +40,10 @@ html {
   overflow-x: hidden; /* prevent horizontal scroll */
 }
 
+p {
+  margin-bottom: 1rem;
+}
+
 /* fixed grayscale background that fades in on scroll */
 body::before {
   content: '';


### PR DESCRIPTION
## Summary
- add default bottom margin to paragraph elements to create visual separation between sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa9b3e398832b9968079c2d8bb49a