### PR TITLE
Add simple password protection

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,14 @@
+(function() {
+  const passkey = 'Kilesand';
+  if (sessionStorage.getItem('authenticated') === 'true') {
+    return;
+  }
+
+  const input = prompt('Skriv inn passord for å få tilgang:');
+
+  if (input === passkey) {
+    sessionStorage.setItem('authenticated', 'true');
+  } else {
+    document.write('<h1>Feil passord</h1>');
+  }
+})();

--- a/fullscreen.html
+++ b/fullscreen.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="auth.js"></script>
   <title>Full-screen Background with Overlay</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
   <style>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="auth.js"></script>
   <title>Anne & Morten gifter seg</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/takk.html
+++ b/takk.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="auth.js"></script>
   <title>Takk for svaret!</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- prompt for passkey before site loads via new `auth.js`
- include password script on all pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688facddac58832bafcc7280711be1d3