### PR TITLE
Add favorite song field to RSVP form

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,11 @@
         <label for="diet">Matpreferanser/allergier (spesifiser hvem det gjelder)</label>
         <textarea id="diet" name="Matpreferanser"></textarea>
       </div>
+
+      <div class="form-group">
+        <label for="song">Favorittsang til dansegulvet</label>
+        <input type="text" id="song" name="Favorittsang" />
+      </div>
       <input type="hidden" name="_subject" value="Bryllupssvar til Anne & Morten">
       <input type="hidden" name="_captcha" value="false">
       <input type="hidden" name="_template" value="basic">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wedding_website",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Static site for Anne and Morten's wedding",
   "scripts": {
     "test": "echo \"No tests specified\""


### PR DESCRIPTION
## Summary
- let guests specify a favorite song for the dance floor in the RSVP form
- bump site version to 1.2.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68986295074c832b98ef8688f773455c