### PR TITLE
Improve form submission responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,12 @@
           ccInput.value = emailInput.value;
         }
 
+        const submitButton = rsvpForm.querySelector('button[type="submit"]');
+        if (submitButton) {
+          submitButton.disabled = true;
+          submitButton.textContent = 'Sender...';
+        }
+
         const data = new FormData(rsvpForm);
         const songInput = document.getElementById('song');
         if (songInput) {
@@ -316,10 +322,11 @@
         fetch('https://script.google.com/macros/s/AKfycbx3DJgM3nWgRE_A9hcxIbMindeTt-apYFWBpP0dF9I2xk-Izu9Kx_0tEW5FlohMNnM/exec', {
           method: 'POST',
           body: data,
-          mode: 'no-cors'
-        }).finally(() => {
-          rsvpForm.submit();
+          mode: 'no-cors',
+          keepalive: true
         });
+
+        rsvpForm.submit();
       });
     }
 

--- a/style.css
+++ b/style.css
@@ -253,6 +253,13 @@ button:hover {
   color: #fff;
 }
 
+button:disabled {
+  background: var(--secondary);
+  color: var(--primary-dark);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 footer {
   text-align: center;
   padding: 2rem;


### PR DESCRIPTION
## Summary
- Disable RSVP submit button and show a sending message to prevent double clicks
- Send background request with `keepalive` and submit immediately for faster redirect
- Style disabled buttons for clearer feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4a42ecc4832bb6eb13f0d95e2941