### PR TITLE
Align ferry time listings

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,17 +106,20 @@
     <p>Et tips ved mye bagasje er å kjøre til ferjekaj for avlessing før parkering av bil. Ved regnvær er det et innendørs venteværelse man kan benytte for dette.</p>
     <h3>Ferje til Koster </h3>
     <p>Et utvalg ferjetider fra Strømstad (norra hamnen) til Ekenäs er:</p>
-    <p><strong>Fredag</strong><br>
-      15:45 - 16:45 (60 min)<br>
-      16:25 - 17:10 (45 min)<br>
-      17:30 - 17:55 (25 min)<br>
-      18:15 - 19:05 (50 min)
-    </p>
+    <p><strong>Fredag</strong></p>
+    <ul class="ferry-times" aria-label="Ferjetider fredag">
+      <li><span>15:45</span><span>-</span><span>16:45</span><span>(60 min)</span></li>
+      <li><span>16:25</span><span>-</span><span>17:10</span><span>(45 min)</span></li>
+      <li><span>17:30</span><span>-</span><span>17:55</span><span>(25 min)</span></li>
+      <li><span>18:15</span><span>-</span><span>19:05</span><span>(50 min)</span></li>
+    </ul>
     <p><strong>Lørdag</strong><br>
-      For gjester som ankommer Koster først på lørdagen anbefaler vi ferjene under til Ekenäs. Da rekker man en tur innom hotellet for å legge fra seg bagasje før ferjen med gjestene går fra Ekenäs til Kilesand for vielsen (se program).<br>
-      08:30 - 09:35 (65 min)<br>
-      11:00 - 11:35 (35 min)
+      For gjester som ankommer Koster først på lørdagen anbefaler vi ferjene under til Ekenäs. Da rekker man en tur innom hotellet for å legge fra seg bagasje før ferjen med gjestene går fra Ekenäs til Kilesand for vielsen (se program).
     </p>
+    <ul class="ferry-times" aria-label="Ferjetider lørdag">
+      <li><span>08:30</span><span>-</span><span>09:35</span><span>(65 min)</span></li>
+      <li><span>11:00</span><span>-</span><span>11:35</span><span>(35 min)</span></li>
+    </ul>
     <p>Andre ferjetider finnes på <a href="https://www.vasttrafik.se/reseplanering/reseplaneraren/">Västtrafik sine nettsider</a>.</p>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -221,6 +221,25 @@ h3 {
   color: var(--text);
 }
 
+.ferry-times {
+  list-style: none;
+  margin: -0.5rem 0 1rem 1.5rem;
+  padding: 0;
+}
+
+.ferry-times li {
+  display: grid;
+  grid-template-columns: 3.25rem 1rem 3.25rem 4.5rem;
+  column-gap: 0.35rem;
+  align-items: baseline;
+  font-variant-numeric: tabular-nums;
+}
+
+.ferry-times li span:nth-child(2),
+.ferry-times li span:nth-child(4) {
+  color: var(--primary-dark);
+}
+
 form {
   background: rgba(221, 213, 180, 0.6);
   backdrop-filter: blur(6px);


### PR DESCRIPTION
### Motivation
- Improve the visual alignment and readability of the ferry schedule by aligning the dash (`-`) and duration (`(`) markers across rows.

### Description
- Converted the inline paragraph ferry times into structured `<ul class="ferry-times">` lists with each row split into four `<span>` elements for departure, dash, arrival, and duration in `index.html`.
- Added `.ferry-times` CSS that uses a grid (`grid-template-columns`) and `font-variant-numeric: tabular-nums` to keep times and markers vertically aligned in `style.css`.
- Added `aria-label` attributes to the new lists to preserve accessibility and screen-reader context.
- Modified files: `index.html` and `style.css`.

### Testing
- Ran `npm test`, which exited successfully though no unit tests are defined. 
- Ran `git diff --check` to validate whitespace/format issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a285e2f0a7c832b8a78165a5a46f445)