### PR TITLE
Add social sharing preview metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,35 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="auth.js"></script>
   <title>Anne & Morten gifter seg</title>
+  <meta name="description" content="Velkommen til Anne og Mortens bryllup på Syd-Koster 27. juni 2026." />
+  <link rel="canonical" href="https://www.anneogmorten.com/" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.anneogmorten.com/" />
+  <meta property="og:title" content="Anne & Morten gifter seg" />
+  <meta property="og:description" content="Velkommen til Anne og Mortens bryllup på Syd-Koster 27. juni 2026." />
+  <meta property="og:image" content="https://www.anneogmorten.com/Thumbnail.png" />
+  <meta property="og:image:secure_url" content="https://www.anneogmorten.com/Thumbnail.png" />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="1024" />
+  <meta property="og:image:height" content="1536" />
+  <meta property="og:image:alt" content="Anne og Morten bryllupsinvitasjon" />
+  <meta property="og:locale" content="nb_NO" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Anne & Morten gifter seg" />
+  <meta name="twitter:description" content="Velkommen til Anne og Mortens bryllup på Syd-Koster 27. juni 2026." />
+  <meta name="twitter:image" content="https://www.anneogmorten.com/Thumbnail.png" />
+  <meta name="twitter:image:alt" content="Anne og Morten bryllupsinvitasjon" />
+  <script src="auth.js"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Caladea&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Alice&family=Playfair+Display:ital@1&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
-  <link rel="thumbnail" type="image/png" href="thumbnail.png">
+  <link rel="image_src" type="image/png" href="https://www.anneogmorten.com/Thumbnail.png">
 </head>
 <body>
 


### PR DESCRIPTION
### Motivation
- Fix missing thumbnail and preview when the site URL is shared by adding standard social metadata so messaging platforms can generate a preview.
- Ensure the public image is referenced with the correct filename casing and an absolute URL so crawlers can find it reliably.

### Description
- Added `description` and `canonical` link elements to the page header for stable page context and URLs.
- Inserted Open Graph metadata (`og:title`, `og:description`, `og:image`, `og:image:width`, `og:image:height`, `og:image:alt`, `og:locale`) pointing to the existing `Thumbnail.png` asset at `https://www.anneogmorten.com/Thumbnail.png`.
- Added Twitter Card metadata (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`, `twitter:image:alt`) to enable large-image cards on Twitter/X.
- Replaced the non-standard lowercase `thumbnail.png` hint with an `image_src` link using the absolute `Thumbnail.png` URL and preserved the existing `auth.js` script inclusion.

### Testing
- Ran `npm test`, which succeeded (project has no unit tests and prints "No tests specified").
- Executed a Python metadata verification script that checked for the presence of the required Open Graph and Twitter tags and confirmed that `Thumbnail.png` exists, and the script passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a286298de20832b8a646b64e12f65fa)