### PR TITLE
Hide page content during auth and fix denial behavior

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,18 +1,35 @@
 (function() {
   const passkey = 'Kilesand';
+  const root = document.documentElement;
+  const authStyle = document.createElement('style');
+
+  authStyle.textContent = 'html.auth-pending body { display: none !important; }';
+  document.head.appendChild(authStyle);
+  root.classList.add('auth-pending');
+
+  function grantAccess() {
+    sessionStorage.setItem('authenticated', 'true');
+    root.classList.remove('auth-pending');
+    authStyle.remove();
+  }
+
+  function denyAccess() {
+    sessionStorage.removeItem('authenticated');
+    alert('Tilgang nektet. Riktig passord kreves for å åpne siden.');
+    window.location.replace('about:blank');
+  }
 
   if (sessionStorage.getItem('authenticated') === 'true') {
+    grantAccess();
     return;
   }
 
   const input = prompt('Skriv inn passord for å få tilgang:');
 
   if (input === passkey) {
-    sessionStorage.setItem('authenticated', 'true');
+    grantAccess();
     return;
   }
 
-  sessionStorage.removeItem('authenticated');
-  alert('Tilgang nektet. Riktig passord kreves for å åpne siden.');
-  window.location.replace('about:blank');
+  denyAccess();
 })();


### PR DESCRIPTION
### Motivation
- Users could dismiss the wrong-password prompt and still see the protected page content, so the page must remain hidden while authentication is pending and redirect on denial. 

### Description
- Add a temporary CSS rule and `html.auth-pending` class to hide the page body while authentication is in progress by injecting a `<style>` element. 
- Introduce `grantAccess()` and `denyAccess()` helper functions to centralize success and failure handling, including `sessionStorage` updates, class removal, and cleanup. 
- Apply `grantAccess()` for stored sessions and correct password entry, and call `denyAccess()` on failure to ensure the page stays hidden and the user is redirected. 

### Testing
- Ran `node --check auth.js` and it completed successfully. 
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29a475ae04832b8ae16dba51ba50ce)